### PR TITLE
Add @:json via tink_json

### DIFF
--- a/src/tink/querystring/macros/GenBuilder.hx
+++ b/src/tink/querystring/macros/GenBuilder.hx
@@ -87,10 +87,12 @@ class GenBuilder {
         case v: i.pos.error('more than one @:formField');
       }
 
+      #if tink_json
       switch i.meta.getValues(':json') {
         case [[]]: i.expr = macro buffer.add(prefix, (tink.Json.stringify(data): String));
         default:
       }
+      #end
       
       return macro @:pos(i.pos) {
         var prefix = switch prefix {

--- a/src/tink/querystring/macros/GenBuilder.hx
+++ b/src/tink/querystring/macros/GenBuilder.hx
@@ -86,6 +86,11 @@ class GenBuilder {
         case [[v]]: v.getName().sure();
         case v: i.pos.error('more than one @:formField');
       }
+
+      switch i.meta.getValues(':json') {
+        case [[]]: i.expr = macro buffer.add(prefix, (tink.Json.stringify(data): String));
+        default:
+      }
       
       return macro @:pos(i.pos) {
         var prefix = switch prefix {

--- a/src/tink/querystring/macros/GenParser.hx
+++ b/src/tink/querystring/macros/GenParser.hx
@@ -185,10 +185,12 @@ class GenParser {
         case v: f.pos.error('more than one @:formField');
       }
 
+      #if tink_json
       switch f.meta.getValues(':json') {
         case [[]]: f.expr = macro tink.Json.parse(this.params.get(prefix));
         default:
       }
+      #end
       
       if (f.optional) 
         optional.push(macro {

--- a/src/tink/querystring/macros/GenParser.hx
+++ b/src/tink/querystring/macros/GenParser.hx
@@ -184,6 +184,11 @@ class GenParser {
         case [[v]]: v.getName().sure();
         case v: f.pos.error('more than one @:formField');
       }
+
+      switch f.meta.getValues(':json') {
+        case [[]]: f.expr = macro tink.Json.parse(this.params.get(prefix));
+        default:
+      }
       
       if (f.optional) 
         optional.push(macro {

--- a/tests/QueryParserTest.hx
+++ b/tests/QueryParserTest.hx
@@ -71,6 +71,19 @@ class QueryParserTest extends TestCase {
     var o = QueryString.parse(('e=ab':{e:MyEnumAbstract}));
     assertFalse(o.isSuccess());
   }
+
+  function testJsonExtension() {
+    var options = {
+      x: 123, y: 'abc'
+    }
+    var fragment = StringTools.urlEncode(tink.Json.stringify(options));
+    var query = 'options=$fragment';
+    var gen = QueryString.build(({options: options}: WithJson));
+    assertEquals(query, gen);
+    var out: WithJson = QueryString.parse(query);
+    assertEquals(options.x, out.options.x);
+    assertEquals(options.y, out.options.y);
+  }
 }
 
 typedef Nested = { 
@@ -79,6 +92,12 @@ typedef Nested = {
     ?y:Array<{ i: Int }>, 
     z:Float,
   }> 
+}
+
+typedef WithJson = {
+  @:json var options: {
+    x: Int, y: String
+  }
 }
 
 @:enum


### PR DESCRIPTION
Would something like this be ok? It makes things easier in tink_web to encode or decode parameters which are json encoded.