### PR TITLE
Hard cast enum abstract to their underlying type if it is compatible with Stringly

### DIFF
--- a/src/tink/querystring/macros/GenBuilder.hx
+++ b/src/tink/querystring/macros/GenBuilder.hx
@@ -116,7 +116,7 @@ class GenBuilder {
   
   public function enumAbstract(names:Array<Expr>, e:Expr, ct:ComplexType, pos:Position):Expr {
     return switch ct.toType() {
-      case Success(TAbstract(_.get() => {type: type = _.getID() => 'String' | 'Int' | 'Float' | 'Bool' | 'Date'}, _)):
+      case Success(TAbstract(_.get() => {type: type}, _)) if(Context.unify(Context.getType('tink.Stringly'), type)):
           var ct = type.toComplex();
           macro buffer.add(prefix, (cast data:$ct));
       case _:

--- a/src/tink/querystring/macros/GenBuilder.hx
+++ b/src/tink/querystring/macros/GenBuilder.hx
@@ -114,8 +114,15 @@ class GenBuilder {
   public function enm(constructors:Array<EnumConstructor>, ct:ComplexType, pos:Position, gen:GenType):Expr
     return throw 'not implemented';
   
-  public function enumAbstract(names:Array<Expr>, e:Expr, ct:ComplexType, pos:Position):Expr
-    return e;
+  public function enumAbstract(names:Array<Expr>, e:Expr, ct:ComplexType, pos:Position):Expr {
+    return switch ct.toType() {
+      case Success(TAbstract(_.get() => {type: type = _.getID() => 'String' | 'Int' | 'Float' | 'Bool' | 'Date'}, _)):
+          var ct = type.toComplex();
+          macro buffer.add(prefix, (cast data:$ct));
+      case _:
+        e;
+    }
+  }
     
   public function rescue(t:Type, pos:Position, gen:GenType):Option<Expr>
     return None;


### PR DESCRIPTION
This apparently fixes haxetink/tink_web#60
But I am not entirely sure about its correctness.