### PR TITLE
fix: Cannot unify final and non-final fields

### DIFF
--- a/src/tink/querystring/macros/GenParser.hx
+++ b/src/tink/querystring/macros/GenParser.hx
@@ -113,8 +113,8 @@ class GenParser {
     
     var ret = macro class $name extends tink.querystring.Parser.ParserBase<$input, $value, $result> {
       
-      function getName(p):String return p.name;
-      function getValue(p):$value return p.value;
+      function getName(p:Named<$value>):String return p.name;
+      function getValue(p:Named<$value>):$value return p.value;
       
       override public function parse(input:$input) {
         var prefix = '';


### PR DESCRIPTION
```haxe
.../libs/tink_querystring/src/tink/querystring/macros/GenParser.hx:121: characters 26-33 : error: Cannot unify final and non-final fields
.../libs/tink_querystring/src/tink/querystring/macros/GenParser.hx:121: characters 26-33 : ... have: ({ name: Dynamic }) -> ...
.../libs/tink_querystring/src/tink/querystring/macros/GenParser.hx:121: characters 26-33 : ... want: ({ name: Dynamic }) -> ...
.../libs/tink_querystring/src/tink/querystring/macros/GenParser.hx:121: characters 26-33 : ... For function argument 'name'
```

I'm not quite sure whether this is the correct type now, but it compiles :angel: 
