### PR TITLE
Normalize parsed tree

### DIFF
--- a/haxe_libraries/deep_equal.hxml
+++ b/haxe_libraries/deep_equal.hxml
@@ -1,0 +1,3 @@
+# @install: lix --silent download "gh://github.com/kevinresol/deep_equal#61d2c6b4b31ccf3e8f31044776025b27e8f46222" into deep_equal/0.3.2/github/61d2c6b4b31ccf3e8f31044776025b27e8f46222
+-cp ${HAXE_LIBCACHE}/deep_equal/0.3.2/github/61d2c6b4b31ccf3e8f31044776025b27e8f46222/src
+-D deep_equal=0.3.2

--- a/src/tink/querystring/Parser.hx
+++ b/src/tink/querystring/Parser.hx
@@ -9,8 +9,7 @@ class Parser<Flow> {}
 
 class ParserBase<Input, Value, Result> { 
   
-  var params:Map<String, Value>;//TODO: consider storing a true hierarchy
-  var exists:Map<String, Bool>;
+  var root:Tree<Value>;
   var onError:Callback<{ name:String, reason:String }>;
   var pos:Pos;
   
@@ -25,30 +24,7 @@ class ParserBase<Input, Value, Result> {
   }
   
   function init<A>(input:Iterator<A>, name:A->String, value:A->Value) {
-    this.params = new Map();
-    this.exists = new Map();
-    
-    if (input != null) 
-      for (pair in input) {
-        var name = name(pair);
-        params[name] = value(pair);
-        var end = name.length;
-        
-        while (end > 0) {
-          
-          name = name.substring(0, end);
-          
-          if (exists[name]) break;
-          
-          exists[name] = true;
-          
-          switch [name.lastIndexOf('[', end - 1), name.lastIndexOf('.', end - 1)] {
-            case [a, b] if (a > b): end = a;
-            case [_, b]: end = b;
-          }
-        }
-      }
-        
+    this.root = new DefaultNormalizer().normalize(input, name, value);
   }
  
   function abort(e)
@@ -79,4 +55,200 @@ class ParserBase<Input, Value, Result> {
     
   function missing(name:String):Dynamic 
     return fail(name, 'Missing value');
+}
+
+@:using(tink.querystring.Parser.FieldTools)
+enum Field<V> {
+  Sub(sub:Tree<V>);
+  Value(v:V);
+}
+
+class FieldTools {
+  public static function toString<V>(f:Field<V>):String {
+    return switch f {
+      case Value(v): Std.string(v);
+      case Sub(tree): tree.toString();
+    }
+  }
+}
+
+@:forward(exists, keyValueIterator, iterator)
+abstract Tree<V>(Map<String, Field<V>>) from Map<String, Field<V>> to Map<String, Field<V>> {
+  public inline function new() 
+    this = [];
+  
+  @:arrayAccess
+  public inline function get(key:String):Field<V>
+    return this[key];
+  
+  @:arrayAccess
+  public inline function set(key:String, value:Field<V>):Field<V>
+    return this[key] = value;
+  
+  public function toString()
+    return str('');
+  
+  function str(indent:String) {
+    final buf = new StringBuf();
+    buf.add('{\n');
+    for(key => value in this)
+      switch value {
+        case Value(v):
+          buf.add(indent + '  $key: "$v",\n');
+        case Sub(sub):
+          buf.add(indent + '  $key: ${sub.str(indent + '  ')},\n');
+      }
+    buf.add(indent + '}');
+    return buf.toString();
+  }
+}
+
+interface Normalizer<Input, Output> {
+  function normalize(input:Iterator<Input>, name:Input->String, value:Input->Output):Tree<Output>;
+}
+
+class DefaultNormalizer<Input, Output> implements Normalizer<Input, Output> {
+  public function new() {}
+  
+  public function normalize(input:Iterator<Input>, name:Input->String, value:Input->Output):Tree<Output> {
+    final root = new Tree();
+    for(entry in input) iterate(root, name(entry), value(entry));
+    return root;
+  }
+  
+  function iterate(tree:Tree<Output>, key:String, value:Output, depth = 0) {
+    // trace(haxe.Json.stringify(key), 1);
+    if(depth == 0) {
+      if(key == '') return; // this should probably throw
+      
+      switch [key.indexOf('['), key.indexOf('.')] {
+        case [-1, -1]:
+          final field = key;
+          
+          switch tree[field] {
+            case null: tree[field] = Value(value);
+            case v: throw 'conflict: $field is already defined as $v';
+          }
+          
+        case [i, -1] | [-1, i]:
+          final field = key.substr(0, i);
+          
+          final sub = switch tree[field] {
+            case null: 
+              final sub = new Tree();
+              tree[field] = Sub(sub);
+              sub;
+            case Sub(sub):
+              sub;
+            case v:
+              throw 'conflict: $field is already defined as $v';
+          }
+          iterate(sub, key.substr(i), value, depth + 1);
+          
+        case [i, j]:
+          // TODO: DRY
+          final index = i > j ? j : i;
+          final field = key.substr(0, index);
+          
+          final sub = switch tree[field] {
+            case null: 
+              final sub = new Tree();
+              tree[field] = Sub(sub);
+              sub;
+            case Sub(sub):
+              sub;
+            case v:
+              throw 'conflict: $field is already defined as $v';
+          }
+          iterate(sub, key.substr(index), value, depth + 1);
+      }
+      
+    } else {
+      final bracket = key.charCodeAt(0) == '['.code;
+      
+      if(bracket) {
+        switch [key.indexOf(']['), key.indexOf('].')] {
+          case [-1, -1]:
+            final field = key.substring(1, key.length - 1);
+            switch tree[field] {
+              case null: tree[field] = Value(value);
+              case v: throw 'conflict: $field is already defined as $v';
+            }
+            
+          case [i, -1] | [-1, i]:
+            final field = key.substring(1, i);
+            
+            final sub = switch tree[field] {
+              case null: 
+                final sub = new Tree();
+                tree[field] = Sub(sub);
+                sub;
+              case Sub(sub):
+                sub;
+              case v:
+                throw 'conflict: $field is already defined as $v';
+            }
+            iterate(sub, key.substr(i + 1), value, depth + 1);
+            
+          case [i, j]:
+            final index = i > j ? j : i;
+            final field = key.substring(1, index);
+            
+            final sub = switch tree[field] {
+              case null: 
+                final sub = new Tree();
+                tree[field] = Sub(sub);
+                sub;
+              case Sub(sub):
+                sub;
+              case v:
+                throw 'conflict: $field is already defined as $v';
+            }
+            iterate(sub, key.substr(index + 1), value, depth + 1);
+        }
+      } else {
+        switch [key.indexOf('['), key.indexOf('.', 1)] {
+          case [-1, -1]:
+            final field = key.substr(1);
+            switch tree[field] {
+              case null: tree[field] = Value(value);
+              case v: throw 'conflict: $field is already defined as $v';
+            }
+            
+          case [i, -1] | [-1, i]:
+            trace('here');
+            final field = key.substring(1, i);
+            
+            final sub = switch tree[field] {
+              case null: 
+                final sub = new Tree();
+                tree[field] = Sub(sub);
+                sub;
+              case Sub(sub):
+                sub;
+              case v:
+                throw 'conflict: $field is already defined as $v';
+            }
+            iterate(sub, key.substr(i), value, depth + 1);
+            
+          case [i, j]:
+            final index = i > j ? j : i;
+            final field = key.substring(1, index);
+            
+            final sub = switch tree[field] {
+              case null: 
+                final sub = new Tree();
+                tree[field] = Sub(sub);
+                sub;
+              case Sub(sub):
+                sub;
+              case v:
+                throw 'conflict: $field is already defined as $v';
+            }
+            iterate(sub, key.substr(index), value, depth + 1);
+        }
+      }
+      
+    }
+  }
 }

--- a/src/tink/querystring/macros/GenParser.hx
+++ b/src/tink/querystring/macros/GenParser.hx
@@ -89,7 +89,7 @@ class GenParser {
         switch to {
           case macro : Int, macro : Float, macro : Date:
             var name = 'parse'+to.toString();
-            macro this.attempt(prefix, $stringly.$name());
+            macro this.attempt(name, $stringly.$name());
           default:
             macro ($stringly : $to);
         }
@@ -120,14 +120,17 @@ class GenParser {
       function getValue(p:tink.core.Named<$value>):$value return p.value;
 
       override public function parse(input:$input) {
-        var prefix = '';
         this.init(input, getName, getValue);
+        final name = '';
+        final field = tink.querystring.Parser.Field.Sub(root);
         return ${crawl.expr};
       }
 
     }
 
     ret.fields = ret.fields.concat(crawl.fields);
+    
+    // trace(new haxe.macro.Printer().printTypeDefinition(ret));
 
     return ret;
   }
@@ -139,19 +142,24 @@ class GenParser {
     return BuildCache.getType('tink.querystring.Parser', buildNew);
 
   public function wrap(placeholder:Expr, ct:ComplexType)
-    return placeholder.func(['prefix'.toArg(macro : String)], ct);
+    return placeholder.func(['name'.toArg(macro:String), 'field'.toArg(macro : tink.querystring.Parser.Field<$value>)], ct);
 
   public function nullable(e:Expr):Expr
     return
       macro
-        if (exists[prefix]) $e;
-        else null;
+        switch field {
+          case null: null;
+          case _: $e;
+        }
 
   function prim(wanted:ComplexType)
     return
-      macro
-        if (exists[prefix]) ((params[prefix]:$value):$wanted);
-        else missing(prefix);
+      macro 
+        switch field {
+          case null: missing(name);
+          case Sub(_): fail(name, 'unexpected object/array');
+          case Value(value): ((value:$value):$wanted);
+        }
 
   public function string():Expr
     return _string;
@@ -194,26 +202,40 @@ class GenParser {
         case v: f.pos.error('more than one @:default');
       }
 
-      var enter = (macro var prefix = switch prefix {
-        case '': $v{formField};
-        case v: v + $v{ '.' + formField};
-      });
+      var enter = (macro var
+        name = $v{formField},
+        tree = switch field {
+          case null: new tink.querystring.Parser.Tree();
+          case Value(_): fail(name, 'unexpected primitive');
+          case Sub(v): v;
+        }
+      );
 
       if (f.optional)
         optional.push(macro {
           $enter;
-          if (exists[prefix])
-            ${['__o', f.name].drill()} = ${f.expr};
-          else ${switch defaultValue {
-            case Some(v): ['__o', f.name].drill().assign(v);
-            default: null;
-          }};
+          switch tree[name] {
+            case null:
+              ${switch defaultValue {
+                case Some(v): ['__o', f.name].drill().assign(v);
+                default: macro null;
+              }}
+            case field:
+              ${['__o', f.name].drill()} = ${f.expr};
+          }
         })
       else {
         var value = switch defaultValue {
           case Some(v):
-            macro if (exists[prefix]) ${f.expr} else $v;
-          default: f.expr;
+            macro switch tree[name] {
+              case null: $v;
+              case field: ${f.expr}
+            }
+          default:
+            macro {
+              final field = tree[name];
+              ${f.expr};
+            }
         }
         ret.push({
           field: f.name,
@@ -233,22 +255,19 @@ class GenParser {
   }
 
   public function array(e:Expr):Expr {
-    return macro {
-
-      var counter = 0,
-          ret = [];
-
-      while (true) {
-        var prefix = prefix + '[' + counter + ']';
-
-        if (exists[prefix]) {
-          ret.push($e);
-          counter++;
-        }
-        else break;
-      }
-
-      ret;
+    return macro switch field {
+      case null:
+        missing(name);
+      case Value(_):
+        fail(name, 'unexpected primitive');
+      case Sub(tree):
+        var ret = [];
+        for(key => field in tree)
+          switch (key:tink.Stringly).parseInt() {
+            case Success(i): ret[i] = $e;
+            case Failure(_): // skip
+          }
+        ret;
     }
   }
   public function map(k:Expr, v:Expr):Expr {

--- a/tests.hxml
+++ b/tests.hxml
@@ -1,7 +1,9 @@
 -cp tests
 -main Run
 -dce full
+
 -lib tink_json
 -lib tink_unittest
+-lib deep_equal
 
 -D no-deprecation-warnings

--- a/tests/NormalizerTest.hx
+++ b/tests/NormalizerTest.hx
@@ -1,0 +1,47 @@
+package;
+
+import tink.querystring.Parser;
+
+using tink.CoreApi;
+
+@:asserts
+class NormalizerTest {
+  public function new() {}
+  
+  public function test() {
+    final normalizer = new DefaultNormalizer();
+    final entries = [
+      new Named('foo.bar', '1'),
+      new Named('foo[baz]', '2'),
+      new Named('foo[deep].1', '3'),
+      new Named('foo[deep].2', '4'),
+      new Named('foo[deep][3]', '5'),
+      new Named('foo[deep][4]', '6'),
+      new Named('foo[3].y[1].i', '7'),
+    ];
+    
+    final tree = normalizer.normalize(entries.iterator(), e -> e.name, e -> e.value);
+    
+    asserts.compare([
+      'foo' => Sub([
+        'bar' => Value('1'),
+        'baz' => Value('2'),
+        'deep' => Sub([
+          '1' => Value('3'),
+          '2' => Value('4'),
+          '3' => Value('5'),
+          '4' => Value('6'),
+        ]),
+        '3' => Sub([
+          'y' => Sub([
+            '1' => Sub([
+              'i' => Value('7')
+            ])
+          ])
+        ])
+      ])
+    ], tree, tree.toString());
+    
+    return asserts.done();
+  }
+}

--- a/tests/QueryParserTest.hx
+++ b/tests/QueryParserTest.hx
@@ -12,31 +12,31 @@ class QueryParserTest {
   
   public function new() {}
 
-  public function base() {
-    /*
-     * The keen observer may notice that the test below tests the implementation - which is why the `@:privateAccess` is there.
-     * This is not really necessary, but given that the macro generated parsers depend on it,
-     * it is helpful to test it in isolation, to be able to better locate bugs in the generated parsers.
-     */
-    var strings = [
-      'o%5B0%5D%5Ba%5D = 1 & o%5B1%5D%5Bc%5D = 1 & x.c = 3 & o%5B1%5D%5Bd%5D.x = 2 & o%5B0%5D%5Bb%5D = 2',
-      'o[0][a]=1 & o[1][c]= 1 & x.c =3 & o[1][d].x= 2& o[0][b] = 2',
-    ];
-    for (string in strings) {
-      var dummy = new ParserBase<Any, Portion, Any>();
+  // public function base() {
+  //   /*
+  //    * The keen observer may notice that the test below tests the implementation - which is why the `@:privateAccess` is there.
+  //    * This is not really necessary, but given that the macro generated parsers depend on it,
+  //    * it is helpful to test it in isolation, to be able to better locate bugs in the generated parsers.
+  //    */
+  //   var strings = [
+  //     'o%5B0%5D%5Ba%5D = 1 & o%5B1%5D%5Bc%5D = 1 & x.c = 3 & o%5B1%5D%5Bd%5D.x = 2 & o%5B0%5D%5Bb%5D = 2',
+  //     'o[0][a]=1 & o[1][c]= 1 & x.c =3 & o[1][d].x= 2& o[0][b] = 2',
+  //   ];
+  //   for (string in strings) {
+  //     var dummy = new ParserBase<Any, Portion, Any>();
       
-      var exists = @:privateAccess {
-        dummy.init(Query.parseString(string), function (p) return p.name, function (p) return p.value);
-        dummy.exists;
-      }
+  //     var exists = @:privateAccess {
+  //       dummy.init(Query.parseString(string), function (p) return p.name, function (p) return p.value);
+  //       dummy.exists;
+  //     }
       
-      var a = [for (k in exists.keys()) k];
-      a.sort(Reflect.compare);
+  //     var a = [for (k in exists.keys()) k];
+  //     a.sort(Reflect.compare);
       
-      asserts.assert('o,o[0],o[0][a],o[0][b],o[1],o[1][c],o[1][d],o[1][d].x,x,x.c' == a.join(','));
-    }
-    return asserts.done();
-  }
+  //     asserts.assert('o,o[0],o[0][a],o[0][b],o[1],o[1][c],o[1][d],o[1][d].x,x,x.c' == a.join(','));
+  //   }
+  //   return asserts.done();
+  // }
 
   public function formField() {
     var o:{
@@ -45,6 +45,33 @@ class QueryParserTest {
     asserts.assert('foo-bar=4' == tink.QueryString.build(o));
     o = tink.QueryString.parse('foo-bar=12');
     asserts.assert(12 == o.fooBar);
+    return asserts.done();
+  }
+  
+  public function anon() {
+    var p = new Parser<{x:Int, y:{?z:Int}}>();
+    var parsed = p.parse('x=1');
+    asserts.assert(parsed.x == 1);
+    asserts.assert(parsed.y.z == null);
+    var parsed = p.parse('x=1&y.z=2');
+    asserts.assert(parsed.x == 1);
+    asserts.assert(parsed.y.z == 2);
+    var parsed = p.parse('x=1&y[z]=2');
+    asserts.assert(parsed.x == 1);
+    asserts.assert(parsed.y.z == 2);
+    return asserts.done();
+  }
+  
+  public function array() {
+    var p = new Parser<{x:Array<Int>}>();
+    var parsed = p.parse('x[0]=1&x[1]=2');
+    asserts.assert(parsed.x[0] == 1);
+    asserts.assert(parsed.x[1] == 2);
+    
+    var p = new Parser<{?x:Array<Int>}>();
+    var parsed = p.parse('x[0]=1&x[1]=2');
+    asserts.assert(parsed.x[0] == 1);
+    asserts.assert(parsed.x[1] == 2);
     return asserts.done();
   }
   
@@ -57,7 +84,7 @@ class QueryParserTest {
     
     var p = new Parser<Nested>();    
     var parsed = p.parse(nestedString);
-    asserts.assert(tink.Json.stringify(nestedObject) == tink.Json.stringify(parsed));
+    asserts.compare(nestedObject, parsed);
     return asserts.done();
   }
   

--- a/tests/QueryParserTest.hx
+++ b/tests/QueryParserTest.hx
@@ -64,12 +64,16 @@ class QueryParserTest {
   
   public function array() {
     var p = new Parser<{x:Array<Int>}>();
-    var parsed = p.parse('x[0]=1&x[1]=2');
+    var parsed = p.parse('x[0]=1&x.1=2');
     asserts.assert(parsed.x[0] == 1);
     asserts.assert(parsed.x[1] == 2);
     
+    var p = new Parser<{x:Array<Int>}>();
+    var parsed = p.parse('');
+    asserts.assert(parsed.x.length == 0);
+    
     var p = new Parser<{?x:Array<Int>}>();
-    var parsed = p.parse('x[0]=1&x[1]=2');
+    var parsed = p.parse('x[0]=1&x.1=2');
     asserts.assert(parsed.x[0] == 1);
     asserts.assert(parsed.x[1] == 2);
     return asserts.done();
@@ -82,7 +86,7 @@ class QueryParserTest {
     o = tink.QueryString.parse(tink.QueryString.build(o));
     asserts.assert(old == o.date.getTime());
     
-    var p = new Parser<Nested>();    
+    var p = new Parser<Nested>();
     var parsed = p.parse(nestedString);
     asserts.compare(nestedObject, parsed);
     return asserts.done();

--- a/tests/Run.hx
+++ b/tests/Run.hx
@@ -7,6 +7,7 @@ class Run {
   
   static function main() {
     Runner.run(TestBatch.make([
+      // new NormalizerTest(),
       new QueryParserTest(),
     ])).handle(Runner.exit);
   }

--- a/tests/Run.hx
+++ b/tests/Run.hx
@@ -7,7 +7,7 @@ class Run {
   
   static function main() {
     Runner.run(TestBatch.make([
-      // new NormalizerTest(),
+      new NormalizerTest(),
       new QueryParserTest(),
     ])).handle(Runner.exit);
   }


### PR DESCRIPTION
This is my attempt to parse the query string into a proper & normalized hierarchy:

```haxe
enum Field<V> {
  Sub(sub:Tree<V>);
  Value(v:V);
}
typedef Tree<V> = Map<String, Field<V>>;
```


So for example the following list of entries:
```haxe
[
  'foo.bar=1',
  'foo[baz]=2',
  'foo[deep].1=3',
  'foo[deep].2=4',
  'foo[deep][3]=5',
  'foo[deep][4]=6',
  'foo[3].y[1].i=7',
]
```

will be parsed into someting like the following (object notiation is `Sub`, string is `Value`):
note that both the `[bracket]` notation and `.dot` notation is now treated the same

```js
{
  foo: {
    3: {
      y: {
        1: {
          i: "7",
        },
      },
    },
    bar: "1",
    baz: "2",
    deep: {
      1: "3",
      2: "4",
      3: "5",
      4: "6",
    },
  },
}
```

and the macro-generated code is adjusted accordingly

(I am too bad at writing parsers so the DefaultNormalizer implementation is really dumb but we can improve it later on)